### PR TITLE
【修复】Linux Release 构建与 HimiiEngine 数据目录同名冲突

### DIFF
--- a/HimiiEditor/CMakeLists.txt
+++ b/HimiiEditor/CMakeLists.txt
@@ -37,11 +37,15 @@ endif()
 
 himii_set_output_dirs(HimiiEditor)
 
-set_target_properties(HimiiEditor PROPERTIES
-    OUTPUT_NAME_RELEASE "HimiiEngine"
-    OUTPUT_NAME_RELWITHDEBINFO "HimiiEngine"
-    OUTPUT_NAME_MINSIZEREL "HimiiEngine"
-)
+# Windows Release 产物品牌名为 HimiiEngine.exe，与 HimiiEngine/ 数据目录可共存；
+# Linux 可执行文件无扩展名，若同名则与 HimiiEngine/ 数据目录冲突，故保持 HimiiEditor。
+if(WIN32)
+    set_target_properties(HimiiEditor PROPERTIES
+        OUTPUT_NAME_RELEASE "HimiiEngine"
+        OUTPUT_NAME_RELWITHDEBINFO "HimiiEngine"
+        OUTPUT_NAME_MINSIZEREL "HimiiEngine"
+    )
+endif()
 
 add_dependencies(HimiiEditor PackEngineResources HimiiRuntime)
 


### PR DESCRIPTION
## 问题

Linux 下执行 Release 构建失败：

```
CMake Error at cmake/EditorPostBuild.cmake:7 (file):
  file failed to create directory:
    build/linux-release/bin/HimiiEditor/Release/HimiiEngine
  because: File exists
```

Release 模式下编辑器二进制被重命名为 `HimiiEngine`，而 POST_BUILD 又要在同一目录创建 `HimiiEngine/` 数据目录（存放 `engine.hpck`、`ScriptCore.dll` 等）。Windows 上二进制带 `.exe` 后缀可与目录共存；Linux 上无扩展名，文件与目录同名直接冲突。

## 修复

将 `OUTPUT_NAME_*` 的 `HimiiEngine` 重命名限定为 `WIN32`：

- Linux Release 编辑器输出名保持 `HimiiEditor`（与 Debug 及 `build.py` 的 Linux 查找逻辑一致）
- `HimiiEngine/` 数据目录布局不变（`Application::GetEngineDir()`、发布管线与 CMake 脚本均依赖该契约）
- Windows 行为完全不变（`HimiiEngine.exe` + `HimiiEngine/` 目录）

## 验证

`cmake --build --preset build-linux-release` 构建成功，产物：

- `build/linux-release/bin/HimiiEditor/Release/HimiiEditor`
- `build/linux-release/bin/HimiiEditor/Release/HimiiEngine/`（`engine.hpck`、`ScriptCore.dll`、`ScriptCore.runtimeconfig.json` 等）

仅剩的 `SyncExportTemplates: HimiiRuntime.exe not found` 警告是 Windows Export Templates 同步逻辑在 Linux 上的预期行为，不影响构建。